### PR TITLE
FIX : 주간 업데이트 조회기능 추가

### DIFF
--- a/research/urls.py
+++ b/research/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from research.views import PublicDataListView, PublicDataDetailView
+from research.views import PublicDataListView, PublicDataDetailView, UpdateDataListView
 
 urlpatterns = [
     path('research', PublicDataListView.as_view()),
-    path('research/<int:id>', PublicDataDetailView.as_view())
+    path('research/<int:id>', PublicDataDetailView.as_view()),
+    path('weekly', UpdateDataListView.as_view()),
 ]

--- a/research/views.py
+++ b/research/views.py
@@ -3,25 +3,32 @@ import json
 from django.http      import JsonResponse
 from django.views     import View
 from django.db.models import Q
-from datetime         import datetime, timedelta, timezone
+from datetime         import datetime, timedelta
 
 from research.models import Research
 
+
 class PublicDataListView(View):
+    """
+    정렬기능, 제목 검색기능을 포함한 데이터 목록 조회 API
+    Writer : 권은경
+    Reviewer : 윤상민, 양수영
+    """
     def get(self, request):
         try:
             sorting = request.GET.get('sort', 'latest')
             search = request.GET.get('search')
-            update_week = request.GET.get('week')
+            institute = request.GET.get('institute')
             OFFSET = int(request.GET.get('offset',0))
             LIMIT = int(request.GET.get('limit', 10))
 
             q = Q()
+
             if search:
                 q &= Q(title__icontains = search)
-            
-            if update_week:
-                q &= Q(updated_at__gte = (timezone.now() - timedelta(days=7)))
+
+            if institute:
+                q &= Q(institute__icontains = institute)
 
             sort = {
                 'latest' : 'created_at',
@@ -29,8 +36,47 @@ class PublicDataListView(View):
                 'update' : 'updated_at'
             }
 
-            research_data_set = Research.objects.filter(q)\
-                                                .order_by(sort[sorting])[OFFSET:OFFSET+LIMIT]
+            search_data_set = Research.objects.filter(q)\
+                                              .order_by(sort[sorting])[OFFSET:OFFSET+LIMIT]
+
+            result = {
+                'data' : [{
+                    'id' : research_data.id,
+                    '과제명' : research_data.title,
+                    '과제 번호' : research_data.number,
+                    '연구 기간' : research_data.duration,
+                    '연구 범위' : research_data.scope,
+                    '연구 종류' : research_data.type,
+                    '연구 책임 기관' : research_data.institute,
+                    '임상 시험 단계': research_data.stage,
+                    '전체 목표 연구 대상자 수' : research_data.target,
+                    '진료과' : research_data.department,
+                }for research_data in search_data_set]
+            }
+            return JsonResponse({'result' : result}, status=200)
+        
+        except KeyError:
+            return JsonResponse({'message' : 'KEY_ERROR'}, status=400)
+
+
+class UpdateDataListView(View):
+    """
+    최근 일주일 동안 업데이트 된 데이터 목록 조회 API
+    Writer : 권은경
+    Reviewer : 윤상민, 양수영
+    """
+    def get(self, request):
+        try:
+            OFFSET = int(request.GET.get('offset',0))
+            LIMIT = int(request.GET.get('limit', 10))
+            now = datetime.now()
+            # now = datetime(year=2022, month=6, day=1) 
+
+            if not Research.objects.filter(updated_at__range=[now - timedelta(days=7), now]).exists():
+                return JsonResponse ({'message' : '업데이트 된 정보가 없습니다.'}, status=404)
+
+            weekly_updated = Research.objects.filter(
+                             updated_at__range=[now - timedelta(days=7), now])[OFFSET:OFFSET+LIMIT]
 
             result = {
                 'data' : [{
@@ -43,14 +89,20 @@ class PublicDataListView(View):
                     '임상 시험 단계': research_data.stage,
                     '전체 목표 연구 대상자 수' : research_data.target,
                     '진료과' : research_data.department,
-                }for research_data in research_data_set]
+                }for research_data in weekly_updated]
             }
             return JsonResponse({'result' : result}, status=200)
         
         except KeyError:
             return JsonResponse({'message' : 'KEY_ERROR'}, status=400)
 
+
 class PublicDataDetailView(View):
+    """
+    연구 데이터 상세 정보 조회 API (id 기준)
+    Writer : 권은경
+    Reviewer : 윤상민, 양수영
+    """
     def get(self, request, id):
         try:
             if not Research.objects.filter(id=id).exists():


### PR DESCRIPTION
## :: 최근 작업 주제
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 최근 일주일간 업데이트 된 자료 조회 기능 추가 

<br />

## :: 구현 사항 설명
- url 추가
- 주간 업데이트 데이터 List 조회 기능 추가
   - 업데이트된 자료가 없을 시 에러 반환 
- 기존의 데이터 List를 불러오는 API는 Search 기능을 추가하여 분리 하였습니다.
- 따라서, 총 3개의 API 
   - `PublicDataListView`(검색, 정렬기능을 포함한 목록 조회)
   - `PublicDataDetailView`(상세정보 조회)
   - `UpdateDataListView`(주간 업데이트 정보 조회) 



<br />

## :: ISSUE
1. 서버 실행시 터미널에 에러 로그가 계속 찍힘 -> 코드 수정해도 바로 반영이 안되어서 서버를 껐다 켜야함 
2. 검색기능 보강 -> 어떤 데이터를 검색할 수 있게 추가할지 고민중 
3. pagination을 기존과 다른방식으로 구현이 가능한지 알아보기 

<br />